### PR TITLE
Allow specifying previously-returned tokens to prevent repeated auth …

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ $ pip3 install ./samsung-tv-api
 from samsungtv import SamsungTV
 
 tv = SamsungTV('192.168.xxx.xxx')
-tv.power() # toggle power
+tv.power() # this will return a token on the command line
+
+
+#tv = SamsungTV('192.168.xxx.xxx', 'YYYYYYY') # using the token from above
 ```
 
 ## License

--- a/example/example.py
+++ b/example/example.py
@@ -4,4 +4,7 @@ sys.path.append('../')
 from samsungtv import SamsungTV
 
 tv = SamsungTV('192.168.xxx.xxx')
-tv.power()
+tv.power() # this will return a token on the command line
+
+
+#tv = SamsungTV('192.168.xxx.xxx', 'YYYYYYY') # using the token from above

--- a/samsungtv/remote.py
+++ b/samsungtv/remote.py
@@ -11,7 +11,7 @@ class SamsungTV():
 
     _KEY_INTERVAL = 1.5
 
-    def __init__(self, host, token='', port=8002, name='SamsungTvRemote'):
+    def __init__(self, host, token, port=8002, name='SamsungTvRemote'):
         self.connection = websocket.create_connection(
             self._URL_FORMAT.format(**{
                 'host': host,


### PR DESCRIPTION
…requests

The library will return an auth token on the command line the first time it's
used - this change seems to allow it to be stored and reused for subsequent
runs.